### PR TITLE
Fix disappearing scroll thumb while actively scrolling.

### DIFF
--- a/fm.scrollator.jquery.js
+++ b/fm.scrollator.jquery.js
@@ -165,6 +165,7 @@ $(window).load(function () {
 						e.preventDefault();
 						e.stopPropagation();
 					}
+					mouseMoveEvent();
 				}
 			}
 		};


### PR DESCRIPTION
This is to make sure the scrollbar remains visible while actively scrolling. Otherwise, after 1.5 second the scrollbar disappears if the mouse did not move.